### PR TITLE
docs: update speaker profile from LinkedIn to Twitter

### DIFF
--- a/april_meetup_2022.md
+++ b/april_meetup_2022.md
@@ -9,7 +9,7 @@ Thanks ❤️ ❤️ for [Microsoft Reactor](https://reactor-ext.azurewebsites.n
 
 ## Speakers
 
-* [Liran Tal - Snyk](https://il.linkedin.com/in/talliran)
+* [Liran Tal - Snyk](https://twitter.com/liran_tal)
 * [Dima Vishnevetsky - ClientSide](https://il.linkedin.com/in/dimshik100)
 
 ## 📹The full playlist


### PR DESCRIPTION
This PR updates Liran's speaker profile from LinkedIn to Twitter, which is more preferred for community engagements :-)